### PR TITLE
Add `--memory-limit` PHP CLI option to the `aom:process` command instead of forcing 1GB memory_limit

### DIFF
--- a/Commands/EventProcessor.php
+++ b/Commands/EventProcessor.php
@@ -47,13 +47,13 @@ class EventProcessor extends ConsoleCommand
     {
 	    $command->setName('aom:process');
 	    $command->setDescription('Processes visits and conversions by updating aom_visits.');
-	    $command->addOption('memory-limit', null, InputOption::VALUE_OPTIONAL, 'Forwards the PHP memory_limit value to the PHP CLI command. For example `--memory-limit=2147483648` would result in the process being allowed 2GB of RAM.', $default = '');
+	    $command->addOption('memory-limit', null, InputOption::VALUE_OPTIONAL, 'Forwards the PHP memory_limit value to the PHP CLI command. For example `--memory-limit=2147483648` would result in the process being allowed 2GB of RAM. Default is to not specify this value and use the server\'s own memory_limit value.', $default = '');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
 
-        // We might need a little more RAM
+        // We might need a little more RAM than what the server's default memory_limit value is so check if the memory-limit option was specified.
         if($input->getOption('memory-limit')){ // Use what was provided via console/cli option
             ini_set('memory_limit',$input->getOption('memory-limit'));
         }

--- a/Commands/EventProcessor.php
+++ b/Commands/EventProcessor.php
@@ -12,6 +12,7 @@ use Piwik\Plugins\AOM\AOM;
 use Piwik\Plugins\AOM\Services\PiwikVisitService;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -38,15 +39,24 @@ class EventProcessor extends ConsoleCommand
 
     protected function configure()
     {
-        $this
-            ->setName('aom:process')
-            ->setDescription('Processes visits and conversions by updating aom_visits.');
+        $this->configureAOMProcessCommand($this);
+    }
+
+    // This is reused by another console command
+    public static function configureAOMProcessCommand(ConsoleCommand $command)
+    {
+	    $command->setName('aom:process');
+	    $command->setDescription('Processes visits and conversions by updating aom_visits.');
+	    $command->addOption('memory-limit', null, InputOption::VALUE_OPTIONAL, 'Forwards the PHP memory_limit value to the PHP CLI command. For example `--memory-limit=2147483648` would result in the process being allowed 2GB of RAM.', $default = '');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+
         // We might need a little more RAM
-        ini_set('memory_limit','1024M');
+        if($input->getOption('memory-limit')){ // Use what was provided via console/cli option
+            ini_set('memory_limit',$input->getOption('memory-limit'));
+        }
 
         $this->logger->info('Starting aom:process run.');
 


### PR DESCRIPTION
I was running into an issue where the ./console aom:process command was requiring more than 1GB. I tried to change my own server's memory_limit via the php.ini, but that didn't do anything. I then found this script was hard-coding a memory_limit of 1GB. This isn't good as different people have different needs and it can certainly be an option rather than being hard-coded into a file which might be overwritten in the future by updating the version of the plugin.

In short, I made this default to the server's own memory_limit so those that instinctively go to modifying their php.ini won't be left confused. Also, I then added a `--memory-limit` option which then allows one to change the memory_limit value to whatever they might need (ex. `./console aom:process --memory-limit=2147483648` would give the script 2GB of memory).