### PR TITLE
Add `--memory-limit` PHP CLI option to the `aom:import` command instead of forcing 2GB memory_limit

### DIFF
--- a/Commands/PlatformImport.php
+++ b/Commands/PlatformImport.php
@@ -41,19 +41,27 @@ class PlatformImport extends ConsoleCommand
 
     protected function configure()
     {
-        $this
-            ->setName('aom:import')
-            ->addOption('platform', null, InputOption::VALUE_REQUIRED)
-            ->addOption('startDate', null, InputOption::VALUE_REQUIRED, 'YYYY-MM-DD')
-            ->addOption('endDate', null, InputOption::VALUE_REQUIRED, 'YYYY-MM-DD')
-            ->addOption('merge', null, InputOption::VALUE_OPTIONAL, 'Merge after import', false)
-            ->setDescription('Import an advertising platform\'s data for a specific period.');
+        $this->configureAOMImportCommand($this);
+    }
+
+    protected function configureAOMImportCommand(ConsoleCommand $command)
+    {
+        $command->setName('aom:import');
+        $command->setDescription('Import an advertising platform\'s data for a specific period.');
+        $command->addOption('platform', null, InputOption::VALUE_REQUIRED);
+        $command->addOption('startDate', null, InputOption::VALUE_REQUIRED, 'YYYY-MM-DD');
+        $command->addOption('endDate', null, InputOption::VALUE_REQUIRED, 'YYYY-MM-DD');
+        $command->addOption('merge', null, InputOption::VALUE_OPTIONAL, 'Merge after import', false);
+        $command->addOption('memory-limit', null, InputOption::VALUE_OPTIONAL, 'Forwards the PHP memory_limit value to the PHP CLI command. For example `--memory-limit=2147483648` would result in the process being allowed 2GB of RAM. Default is to not specify this value and use the server\'s own memory_limit value.', $default = '');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        // We might need a little more RAM
-        ini_set('memory_limit','2048M');
+
+        // We might need a little more RAM than what the server's default memory_limit value is so check if the memory-limit option was specified.
+        if($input->getOption('memory-limit')){ // Use what was provided via console/cli option
+            ini_set('memory_limit',$input->getOption('memory-limit'));
+        }
 
         if (!in_array($input->getOption('platform'), AOM::getPlatforms())) {
             $this->logger->warning('Platform "' . $input->getOption('platform') . '" is not supported.');


### PR DESCRIPTION
I was running into an issue where the ./console aom:import command was requiring more than 2GB. I then found this script was hard-coding a memory_limit of 2GB. This isn't good as different people have different needs and it can certainly be an option rather than being hard-coded into a file which might be overwritten in the future by updating the version of the plugin.

In short, I made this default to the server's own memory_limit so those that instinctively go to modifying their php.ini won't be left confused. Also, I then added a --memory-limit option which then allows one to change the memory_limit value to whatever they might need (ex. ./console aom:import --memory-limit=34359720776 would give the script 34GB of memory).